### PR TITLE
Throws Exception while trying to "add" a new attribute on the product page.

### DIFF
--- a/src/WellCommerce/Bundle/AttributeBundle/Manager/AttributeManager.php
+++ b/src/WellCommerce/Bundle/AttributeBundle/Manager/AttributeManager.php
@@ -33,7 +33,7 @@ class AttributeManager extends AbstractManager
         }
         $attribute->addGroup($group);
         $attribute->mergeNewTranslations();
-        $this->saveResource($attribute);
+        $this->createResource($attribute);
 
         return $attribute;
     }

--- a/src/WellCommerce/Bundle/AttributeBundle/Manager/AttributeValueManager.php
+++ b/src/WellCommerce/Bundle/AttributeBundle/Manager/AttributeValueManager.php
@@ -47,7 +47,7 @@ class AttributeValueManager extends AbstractManager
 
         $value->mergeNewTranslations();
         $value->addAttribute($attribute);
-        $this->saveResource($value);
+        $this->createResource($value);
 
         return $value;
     }


### PR DESCRIPTION
I noticed today that the saveResource method was not defined. I am new to Symfony and WellCommerce so I guess we want to use createResource method instead.