### PR TITLE
add checksum field in Media entity

### DIFF
--- a/src/WellCommerce/Bundle/AppBundle/Entity/Media.php
+++ b/src/WellCommerce/Bundle/AppBundle/Entity/Media.php
@@ -14,6 +14,7 @@ namespace WellCommerce\Bundle\AppBundle\Entity;
 
 use Knp\DoctrineBehaviors\Model\Blameable\Blameable;
 use Knp\DoctrineBehaviors\Model\Timestampable\Timestampable;
+use Symfony\Component\HttpFoundation\File\File;
 use WellCommerce\Bundle\CoreBundle\Doctrine\Behaviours\Identifiable;
 use WellCommerce\Bundle\CoreBundle\Entity\EntityInterface;
 
@@ -33,7 +34,13 @@ class Media implements EntityInterface
     protected $extension = '';
     protected $mime      = '';
     protected $size      = 0;
-    
+    protected $checksum  = null;
+
+    /**
+     * @var null|File
+     */
+    protected $tmpFile = null;
+
     public function getName(): string
     {
         return $this->name;
@@ -95,5 +102,27 @@ class Media implements EntityInterface
             $filename   = sha1($this->name);
             $this->path = sprintf('%s.%s', $filename, $this->getExtension());
         }
+    }
+
+    public function getChecksum()
+    {
+        return $this->checksum;
+    }
+
+    public function getTmpFile()
+    {
+        return $this->tmpFile;
+    }
+
+    public function setTmpFile(File $tmpFile)
+    {
+        if($tmpFile->isFile()){
+            $this->checksum = md5_file($tmpFile->getPathname());
+            $this->tmpFile = $tmpFile;
+        }
+    }
+
+    public function resetTmpFile(){
+        $this->tmpFile = null;
     }
 }

--- a/src/WellCommerce/Bundle/AppBundle/EventListener/MediaDoctrineEventSubscriber.php
+++ b/src/WellCommerce/Bundle/AppBundle/EventListener/MediaDoctrineEventSubscriber.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace WellCommerce\Bundle\AppBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Symfony\Component\Filesystem\Filesystem;
+use WellCommerce\Bundle\AppBundle\Entity\Media;
+use WellCommerce\Bundle\AppBundle\Service\Media\Uploader\MediaUploaderInterface;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+
+class MediaDoctrineEventSubscriber implements EventSubscriber
+{
+    protected $mediaUploadDir;
+    protected $filesystem;
+
+    public function __construct(Filesystem $filesystem, string $mediaUploadDir)
+    {
+        $this->filesystem = $filesystem;
+        $this->mediaUploadDir = $mediaUploadDir;
+    }
+
+    public function getSubscribedEvents()
+    {
+        return [
+            'postPersist',
+            'postUpdate',
+            'preRemove'
+        ];
+    }
+
+    public function postUpdate(LifecycleEventArgs $args)
+    {
+        $this->onPostDataUpdate($args);
+    }
+
+    public function postPersist(LifecycleEventArgs $args)
+    {
+        $this->onPostDataUpdate($args);
+    }
+
+    public function preRemove(LifecycleEventArgs $args)
+    {
+        $media = $args->getEntity();
+
+        if ($media instanceof Media) {
+            $file = $this->mediaUploadDir . $media->getPath();
+            if ($this->filesystem->exists($file)) {
+                $this->filesystem->remove($file);
+            }
+        }
+    }
+
+    protected function onPostDataUpdate(LifecycleEventArgs $args)
+    {
+        $media = $args->getEntity();
+
+        if ($media instanceof Media) {
+            $tmpFile = $media->getTmpFile();
+
+            if ($tmpFile) {
+                $tmpFile->move($this->mediaUploadDir, $media->getPath());
+                $media->resetTmpFile();
+            }
+        }
+    }
+}

--- a/src/WellCommerce/Bundle/AppBundle/Resources/config/doctrine/Media.orm.yml
+++ b/src/WellCommerce/Bundle/AppBundle/Resources/config/doctrine/Media.orm.yml
@@ -34,6 +34,12 @@ WellCommerce\Bundle\AppBundle\Entity\Media:
             type: string
             length: 12
             nullable: true
+        checksum:
+            type: string
+            length: 32
+            nullable: true
+            unique: true
+
     lifecycleCallbacks:
         prePersist:
             - preUpload

--- a/src/WellCommerce/Bundle/AppBundle/Resources/config/services/media.yml
+++ b/src/WellCommerce/Bundle/AppBundle/Resources/config/services/media.yml
@@ -24,3 +24,9 @@ services:
     media.uploader:
         class: WellCommerce\Bundle\AppBundle\Service\Media\Uploader\MediaUploader
         arguments: ['@media.manager', '%kernel.root_dir%/../web/media', '@validator.helper']
+
+    media.doctrine.event_subscriber:
+        class: WellCommerce\Bundle\AppBundle\EventListener\MediaDoctrineEventSubscriber
+        arguments: ["@filesystem", '%kernel.root_dir%/../web/media/images/']
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }

--- a/src/WellCommerce/Bundle/AppBundle/Service/Media/Uploader/MediaUploader.php
+++ b/src/WellCommerce/Bundle/AppBundle/Service/Media/Uploader/MediaUploader.php
@@ -66,14 +66,14 @@ final class MediaUploader implements MediaUploaderInterface
         $media->setExtension($file->guessClientExtension());
         $media->setMime($file->getClientMimeType());
         $media->setSize($file->getClientSize());
-        
+        $media->setTmpFile($file);
+
         $errors = $this->validatorHelper->validate($media);
         if (0 !== count($errors)) {
             throw new InvalidMediaException($errors);
         }
         
         $this->manager->createResource($media);
-        $file->move($this->getUploadDir($dir), $media->getPath());
         
         return $media;
     }


### PR DESCRIPTION
Added checksum field in Media entity for find by 'checksum'.
Changed logic for add/upload/remove local files with MediaDoctrineEventSubscriber. 
For add local file need set Media::tmpFile in instance of File (or any another inheritor), this file move in upload dir on postPersist/postUpdate event.
Checksum set when call Media::setTmpFile(File $tmpFile)